### PR TITLE
feat: add Jenkins pipeline and k8s manifests for ruoyi-cloud

### DIFF
--- a/deploy/ci-cd/Jenkinsfile
+++ b/deploy/ci-cd/Jenkinsfile
@@ -1,0 +1,120 @@
+pipeline {
+  agent { label 'docker' }
+  environment {
+    REGISTRY = "harbor.example.com"
+    HARBOR_PROJECT = "ruoyi"
+    K8S_NAMESPACE = "ruoyi"
+    NPM_REGISTRY = "https://registry.npmmirror.com"
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '20'))
+    disableConcurrentBuilds()
+    timestamps()
+  }
+  triggers {
+    pollSCM('@daily')
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scm
+      }
+    }
+    stage('Initialize') {
+      steps {
+        script {
+          env.IMAGE_TAG = "${env.BUILD_NUMBER}-${env.GIT_COMMIT?.take(7) ?: 'snapshot'}"
+          env.BUILD_DATE = sh(returnStdout: true, script: 'date -u +%Y%m%d%H%M%S').trim()
+        }
+      }
+    }
+    stage('Maven Build') {
+      steps {
+        sh 'mvn -B clean package -DskipTests'
+      }
+    }
+    stage('Frontend Build') {
+      steps {
+        dir('ruoyi-ui') {
+          sh 'npm install --registry=${NPM_REGISTRY}'
+          sh 'npm run build:prod'
+        }
+      }
+    }
+    stage('Prepare Docker Context') {
+      steps {
+        sh 'cd docker && bash copy.sh'
+      }
+    }
+    stage('Build & Push Images') {
+      steps {
+        script {
+          def services = [
+            [name: 'ruoyi-gateway', context: 'docker/ruoyi/gateway'],
+            [name: 'ruoyi-auth', context: 'docker/ruoyi/auth'],
+            [name: 'ruoyi-modules-system', context: 'docker/ruoyi/modules/system'],
+            [name: 'ruoyi-modules-file', context: 'docker/ruoyi/modules/file'],
+            [name: 'ruoyi-modules-gen', context: 'docker/ruoyi/modules/gen'],
+            [name: 'ruoyi-modules-job', context: 'docker/ruoyi/modules/job'],
+            [name: 'ruoyi-visual-monitor', context: 'docker/ruoyi/visual/monitor'],
+            [name: 'ruoyi-ui', context: 'docker/nginx']
+          ]
+          withCredentials([
+            usernamePassword(credentialsId: 'harbor-credential-id', usernameVariable: 'HARBOR_USER', passwordVariable: 'HARBOR_PASSWORD')
+          ]) {
+            sh '''
+              set -e
+              echo "$HARBOR_PASSWORD" | docker login ${REGISTRY} -u "$HARBOR_USER" --password-stdin
+            '''
+            services.each { svc ->
+              sh """
+                set -e
+                docker build -t ${REGISTRY}/${HARBOR_PROJECT}/${svc.name}:${env.IMAGE_TAG} \
+                  --build-arg BUILD_DATE=${env.BUILD_DATE} \
+                  --build-arg VCS_REF=${env.GIT_COMMIT} \
+                  -f ${svc.context}/dockerfile ${svc.context}
+                docker push ${REGISTRY}/${HARBOR_PROJECT}/${svc.name}:${env.IMAGE_TAG}
+                docker tag ${REGISTRY}/${HARBOR_PROJECT}/${svc.name}:${env.IMAGE_TAG} ${REGISTRY}/${HARBOR_PROJECT}/${svc.name}:latest
+                docker push ${REGISTRY}/${HARBOR_PROJECT}/${svc.name}:latest
+              """
+            }
+          }
+        }
+      }
+    }
+    stage('Deploy to Kubernetes') {
+      steps {
+        script {
+          withCredentials([
+            file(credentialsId: 'kubeconfig-ruoyi', variable: 'KUBECONFIG_FILE')
+          ]) {
+            sh """
+              set -e
+              export KUBECONFIG=${KUBECONFIG_FILE}
+              kubectl apply -k deploy/k8s/overlays/prod
+              kubectl set image deployment/ruoyi-gateway ruoyi-gateway=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-gateway:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-auth ruoyi-auth=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-auth:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-system ruoyi-system=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-modules-system:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-file ruoyi-file=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-modules-file:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-gen ruoyi-gen=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-modules-gen:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-job ruoyi-job=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-modules-job:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-monitor ruoyi-monitor=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-visual-monitor:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+              kubectl set image deployment/ruoyi-ui ruoyi-ui=${REGISTRY}/${HARBOR_PROJECT}/ruoyi-ui:${env.IMAGE_TAG} -n ${K8S_NAMESPACE}
+            """
+          }
+        }
+      }
+    }
+  }
+  post {
+    success {
+      echo "Pipeline finished successfully"
+    }
+    failure {
+      echo "Pipeline failed"
+    }
+    always {
+      sh 'docker image prune -f || true'
+    }
+  }
+}

--- a/deploy/k8s/base/configmap-ruoyi-env.yaml
+++ b/deploy/k8s/base/configmap-ruoyi-env.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ruoyi-env
+  labels:
+    app.kubernetes.io/name: ruoyi
+    app.kubernetes.io/part-of: ruoyi-cloud
+    app.kubernetes.io/component: configuration
+    app.kubernetes.io/version: v1
+    app.kubernetes.io/managed-by: manual
+    app.kubernetes.io/instance: ruoyi-env
+  namespace: ruoyi
+data:
+  NACOS_ADDR: "nacos.ruoyi.svc.cluster.local:8848"
+  NACOS_NAMESPACE: "public"
+  NACOS_USERNAME: "nacos"
+  NACOS_PASSWORD: "nacos"
+  SENTINEL_ADDR: "sentinel.ruoyi.svc.cluster.local:8718"
+  REDIS_ADDR: "redis-master.ruoyi.svc.cluster.local:6379"
+  MYSQL_HOST: "mysql.ruoyi.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  MYSQL_DATABASE: "ry-cloud"
+  MYSQL_TIMEZONE: "+08:00"
+  JAVA_OPTS: "-Xms512m -Xmx512m -Duser.timezone=Asia/Shanghai"

--- a/deploy/k8s/base/deployment-ruoyi-auth.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-auth.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-auth
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-auth
+    app.kubernetes.io/component: auth
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-auth
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-auth
+        app.kubernetes.io/component: auth
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-auth
+          image: harbor.example.com/ruoyi/ruoyi-auth:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9200
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-auth
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-auth
+    app.kubernetes.io/component: auth
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-auth
+  ports:
+    - port: 9200
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-file.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-file.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-file
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-file
+    app.kubernetes.io/component: file
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-file
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-file
+        app.kubernetes.io/component: file
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-file
+          image: harbor.example.com/ruoyi/ruoyi-modules-file:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9300
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-file
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-file
+    app.kubernetes.io/component: file
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-file
+  ports:
+    - port: 9300
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-gateway.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-gateway.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-gateway
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-gateway
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-gateway
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-gateway
+          image: harbor.example.com/ruoyi/ruoyi-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_SENTINEL_TRANSPORT_DASHBOARD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: SENTINEL_ADDR
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-gateway
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-gateway
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-gateway
+  ports:
+    - port: 8080
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-gen.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-gen.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-gen
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-gen
+    app.kubernetes.io/component: gen
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-gen
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-gen
+        app.kubernetes.io/component: gen
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-gen
+          image: harbor.example.com/ruoyi/ruoyi-modules-gen:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9202
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-gen
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-gen
+    app.kubernetes.io/component: gen
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-gen
+  ports:
+    - port: 9202
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-job.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-job.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-job
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-job
+    app.kubernetes.io/component: job
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-job
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-job
+        app.kubernetes.io/component: job
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-job
+          image: harbor.example.com/ruoyi/ruoyi-modules-job:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9203
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-job
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-job
+    app.kubernetes.io/component: job
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-job
+  ports:
+    - port: 9203
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-monitor.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-monitor.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-monitor
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-monitor
+    app.kubernetes.io/component: monitor
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-monitor
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-monitor
+        app.kubernetes.io/component: monitor
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-monitor
+          image: harbor.example.com/ruoyi/ruoyi-visual-monitor:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9100
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-monitor
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-monitor
+    app.kubernetes.io/component: monitor
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-monitor
+  ports:
+    - port: 9100
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-system.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-system.yaml
@@ -1,0 +1,115 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-system
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-system
+    app.kubernetes.io/component: system
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-system
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-system
+        app.kubernetes.io/component: system
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-system
+          image: harbor.example.com/ruoyi/ruoyi-modules-system:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9201
+              name: http
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: prod
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_DISCOVERY_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: SPRING_CLOUD_NACOS_CONFIG_SERVER_ADDR
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_ADDR
+            - name: SPRING_CLOUD_NACOS_CONFIG_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_NAMESPACE
+            - name: SPRING_CLOUD_NACOS_CONFIG_USERNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_USERNAME
+            - name: SPRING_CLOUD_NACOS_CONFIG_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: NACOS_PASSWORD
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: JAVA_OPTS
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-system
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-system
+    app.kubernetes.io/component: system
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-system
+  ports:
+    - port: 9201
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/deployment-ruoyi-ui.yaml
+++ b/deploy/k8s/base/deployment-ruoyi-ui.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ruoyi-ui
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-ui
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ruoyi-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ruoyi-ui
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      imagePullSecrets:
+        - name: ruoyi-harbor
+      containers:
+        - name: ruoyi-ui
+          image: harbor.example.com/ruoyi/ruoyi-ui:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ruoyi-ui
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-ui
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: ruoyi-ui
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+  type: ClusterIP

--- a/deploy/k8s/base/ingress-ruoyi.yaml
+++ b/deploy/k8s/base/ingress-ruoyi.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ruoyi
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi
+    app.kubernetes.io/part-of: ruoyi-cloud
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: gateway.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ruoyi-gateway
+                port:
+                  name: http
+    - host: ruoyi.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ruoyi-ui
+                port:
+                  name: http

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,37 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ruoyi
+resources:
+  - namespace.yaml
+  - configmap-ruoyi-env.yaml
+  - secret-mysql.yaml
+  - mysql-statefulset.yaml
+  - redis-statefulset.yaml
+  - nacos-statefulset.yaml
+  - sentinel-deployment.yaml
+  - deployment-ruoyi-gateway.yaml
+  - deployment-ruoyi-auth.yaml
+  - deployment-ruoyi-system.yaml
+  - deployment-ruoyi-file.yaml
+  - deployment-ruoyi-gen.yaml
+  - deployment-ruoyi-job.yaml
+  - deployment-ruoyi-monitor.yaml
+  - deployment-ruoyi-ui.yaml
+  - ingress-ruoyi.yaml
+images:
+  - name: harbor.example.com/ruoyi/ruoyi-gateway
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-auth
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-modules-system
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-modules-file
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-modules-gen
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-modules-job
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-visual-monitor
+    newTag: latest
+  - name: harbor.example.com/ruoyi/ruoyi-ui
+    newTag: latest

--- a/deploy/k8s/base/mysql-statefulset.yaml
+++ b/deploy/k8s/base/mysql-statefulset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+  serviceName: mysql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3306
+              name: mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ruoyi-mysql
+                  key: MYSQL_ROOT_PASSWORD
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: MYSQL_DATABASE
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ruoyi-mysql
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ruoyi-mysql
+                  key: MYSQL_PASSWORD
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: mysql
+  ports:
+    - port: 3306
+      targetPort: mysql
+      name: mysql

--- a/deploy/k8s/base/nacos-statefulset.yaml
+++ b/deploy/k8s/base/nacos-statefulset.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nacos
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: nacos
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  serviceName: nacos-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nacos
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nacos
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      containers:
+        - name: nacos
+          image: nacos/nacos-server:v2.2.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8848
+              name: client
+            - containerPort: 9848
+              name: cluster
+            - containerPort: 9849
+              name: cluster-raft
+          env:
+            - name: MODE
+              value: standalone
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: mysql
+            - name: MYSQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: MYSQL_HOST
+            - name: MYSQL_SERVICE_DB_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: MYSQL_DATABASE
+            - name: MYSQL_SERVICE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: ruoyi-env
+                  key: MYSQL_PORT
+            - name: MYSQL_SERVICE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: ruoyi-mysql
+                  key: MYSQL_USER
+            - name: MYSQL_SERVICE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ruoyi-mysql
+                  key: MYSQL_PASSWORD
+          volumeMounts:
+            - name: nacos-data
+              mountPath: /home/nacos/data
+            - name: nacos-logs
+              mountPath: /home/nacos/logs
+      volumes:
+        - name: nacos-data
+          emptyDir: {}
+        - name: nacos-logs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nacos
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: nacos
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: nacos
+  ports:
+    - port: 8848
+      targetPort: client
+      name: client
+    - port: 9848
+      targetPort: cluster
+      name: cluster
+    - port: 9849
+      targetPort: cluster-raft
+      name: cluster-raft
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nacos-headless
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: nacos
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: nacos
+  ports:
+    - port: 8848
+      targetPort: client
+      name: client

--- a/deploy/k8s/base/namespace.yaml
+++ b/deploy/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi
+    app.kubernetes.io/part-of: ruoyi-cloud

--- a/deploy/k8s/base/redis-statefulset.yaml
+++ b/deploy/k8s/base/redis-statefulset.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  serviceName: redis-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.2-alpine
+          ports:
+            - containerPort: 6379
+              name: redis
+          args:
+            - redis-server
+            - "--appendonly"
+            - "yes"
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      volumes:
+        - name: redis-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - port: 6379
+      targetPort: redis
+      name: redis

--- a/deploy/k8s/base/secret-mysql.yaml
+++ b/deploy/k8s/base/secret-mysql.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ruoyi-mysql
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: ruoyi-mysql
+    app.kubernetes.io/part-of: ruoyi-cloud
+type: Opaque
+stringData:
+  MYSQL_USER: ruoyi
+  MYSQL_PASSWORD: ChangeMe@123
+  MYSQL_ROOT_PASSWORD: ChangeMeRoot@123

--- a/deploy/k8s/base/sentinel-deployment.yaml
+++ b/deploy/k8s/base/sentinel-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sentinel
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: sentinel
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sentinel
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sentinel
+        app.kubernetes.io/part-of: ruoyi-cloud
+    spec:
+      containers:
+        - name: sentinel
+          image: bladex/sentinel-dashboard:1.8.6
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: JAVA_OPTS
+              value: "-Dserver.port=8718 -Dcsp.sentinel.dashboard.server=127.0.0.1:8718 -Dproject.name=sentinel-dashboard"
+          ports:
+            - containerPort: 8718
+              name: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentinel
+  namespace: ruoyi
+  labels:
+    app.kubernetes.io/name: sentinel
+    app.kubernetes.io/part-of: ruoyi-cloud
+spec:
+  selector:
+    app.kubernetes.io/name: sentinel
+  type: ClusterIP
+  ports:
+    - port: 8718
+      targetPort: http
+      name: http

--- a/deploy/k8s/overlays/prod/ingress-hosts-patch.yaml
+++ b/deploy/k8s/overlays/prod/ingress-hosts-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/rules/0/host
+  value: gateway.prod.example.com
+- op: replace
+  path: /spec/rules/1/host
+  value: ruoyi.prod.example.com

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ruoyi
+commonLabels:
+  app.kubernetes.io/environment: prod
+resources:
+  - ../../base
+patchesJson6902:
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      name: ruoyi
+    path: ingress-hosts-patch.yaml

--- a/docs/ci-cd/aliyun-ecs-k8s.md
+++ b/docs/ci-cd/aliyun-ecs-k8s.md
@@ -1,0 +1,160 @@
+# 基于阿里云 ECS 的 ruoyi-cloud CI/CD 部署指南
+
+本文档面向已经在阿里云 ECS 自建 Kubernetes 集群，并完成 Harbor、Jenkins、GitLab 安装的场景，说明如何借助本仓库新增的流水线脚本与 Kubernetes 清单，实现 ruoyi-cloud 项目的自动化构建、发布与运维。
+
+## 1. 整体架构
+
+```
+GitLab (源代码)
+   │  Webhook / Jenkins GitLab 插件
+   ▼
+Jenkins Pipeline (deploy/ci-cd/Jenkinsfile)
+   │  mvn & npm 构建 / Docker Buildx / 镜像推送
+   ▼
+Harbor (ruoyi 项目镜像仓库)
+   │  kubectl apply -k deploy/k8s/overlays/prod
+   ▼
+Kubernetes (ECS 节点)
+   ├─ 基础设施：MySQL、Redis、Nacos、Sentinel
+   └─ 微服务：Gateway、Auth、System、File、Gen、Job、Monitor、UI
+```
+
+## 2. 前置条件
+
+1. **Kubernetes 集群**：
+   - 建议基于至少 3 台 ECS 节点（1 主 2 从）安装 Kubernetes 1.24+，或直接使用 ACK。
+   - 安装 `containerd`/`docker`、`kubectl`、`helm`（可选），配置 `calico`/`flannel` 网络插件。
+2. **存储/负载均衡**：
+   - 示例清单使用 `emptyDir`，生产环境请为 MySQL、Nacos、Redis 配置云盘或 NAS 的 PVC，并结合阿里云 SLB / Ingress Controller 暴露服务。
+3. **GitLab**：
+   - 创建 `ruoyi-cloud` 仓库，导入本项目代码。
+   - 在 *Settings → Webhooks* 中配置 Jenkins 回调地址（`http://jenkins.example.com/project/ruoyi-cloud`）。
+4. **Harbor**：
+   - 创建名为 `ruoyi` 的项目，获取一个拥有推送权限的 Robot 账号或普通用户。
+5. **Jenkins**：
+   - 安装插件：GitLab、Pipeline、Kubernetes CLI、NodeJS、Blue Ocean（可选）。
+   - Jenkins agent 需安装：`jdk11+`、`maven`、`node 16+`、`npm`、`docker`、`kubectl`、`kustomize`。
+   - 配置全局工具：Maven、NodeJS（可选）。
+
+## 3. Jenkins 凭据约定
+
+在 Jenkins 「凭据」中新增以下条目，与 Jenkinsfile 保持一致：
+
+| ID | 类型 | 说明 |
+| --- | --- | --- |
+| `harbor-credential-id` | Username/Password | Harbor 推送账号（Robot 或普通用户） |
+| `kubeconfig-ruoyi` | Secret file | 具备 `ruoyi` 命名空间管理权限的 kubeconfig |
+| `gitlab-api-token`（可选） | Secret text | 若需通过 API 触发 MR 状态回调 |
+
+> 如需使用 GitLab webhook 触发，请在 Jenkins 新建「GitLab 项目」或「多分支流水线」并关联上述凭据。
+
+## 4. 新增 Jenkins Pipeline
+
+1. 在 Jenkins 创建 *Pipeline* 作业，`Pipeline script from SCM` 指向 GitLab 仓库，分支如 `master/main`。
+2. Jenkinsfile 路径设为 `deploy/ci-cd/Jenkinsfile`。
+3. 保存后即可手动或通过 GitLab Webhook 触发流水线。
+
+### 4.1 流水线阶段说明
+
+| 阶段 | 动作 |
+| --- | --- |
+| `Checkout` | 从 GitLab 拉取代码 |
+| `Initialize` | 生成 `IMAGE_TAG`（`构建号-提交ID`）、记录构建时间 |
+| `Maven Build` | 执行 `mvn -B clean package -DskipTests`，构建后端 Jar |
+| `Frontend Build` | 在 `ruoyi-ui` 目录运行 `npm install`、`npm run build:prod` 构建前端静态资源 |
+| `Prepare Docker Context` | 调用 `docker/copy.sh`，将 Jar / 前端静态文件拷贝到 Docker 构建上下文 |
+| `Build & Push Images` | 登录 Harbor，构建并推送 8 个服务镜像（含 `latest` 和构建标签） |
+| `Deploy to Kubernetes` | `kubectl apply -k deploy/k8s/overlays/prod` 部署基础设施+业务服务，并使用 `kubectl set image` 滚动更新容器镜像 |
+
+流水线失败时 Jenkins 自动标记失败；成功后会执行 `docker image prune -f` 清理构建节点残余镜像层。
+
+## 5. Kubernetes 清单使用说明
+
+新增的 Kubernetes 清单位于 `deploy/k8s`：
+
+- `base/`：包含命名空间、配置、基础服务（MySQL/Redis/Nacos/Sentinel）以及 ruoyi 各微服务的 Deployment/Service/Ingress。镜像默认指向 `harbor.example.com`，实际部署前需修改为企业 Harbor 地址。
+- `overlays/prod/`：示例化的生产覆写，给 Ingress 规则加上生产域名标签，可按需扩展更多环境（如 `dev`、`staging`）。
+
+### 5.1 初始化命名空间与镜像拉取密钥
+
+```bash
+# 创建命名空间（首次部署时执行）
+kubectl create namespace ruoyi
+
+# 将 Harbor Robot 账号创建为镜像拉取密钥
+kubectl -n ruoyi create secret docker-registry ruoyi-harbor \
+  --docker-server=harbor.example.com \
+  --docker-username='robot$ruoyi' \
+  --docker-password='xxxxxxxx' \
+  --docker-email='devops@example.com'
+```
+
+### 5.2 同步配置与数据库
+
+1. 将 `sql/` 目录中的 `ry_*.sql` 导入到 Kubernetes 内部或外部 MySQL 中：
+
+```bash
+kubectl -n ruoyi exec -it statefulset/mysql -- bash -c "mysql -uroot -p$MYSQL_ROOT_PASSWORD < /docker-entrypoint-initdb.d/ry_20250523.sql"
+```
+
+2. 登录 Nacos 控制台（`http://<任意节点>:8848/nacos`，默认用户/密码 `nacos/nacos`），导入 `sql/ry_config_20250224.sql` 中的配置，或按需手动创建 `application-prod.yml` 等配置文件。
+3. 根据实际环境修改 `deploy/k8s/base/configmap-ruoyi-env.yaml` 中的：
+   - `NACOS_ADDR`、`SENTINEL_ADDR`（如果使用外部组件）；
+   - `MYSQL_*` 参数；
+   - `JAVA_OPTS`（JVM 资源限制）。
+4. **生产环境建议**：为 MySQL、Nacos、Redis 配置持久化卷（替换 `emptyDir`）、开启账号复杂度、并限制 Node 选择器 / 亲和性。
+
+### 5.3 部署
+
+```bash
+# 首次部署全部资源
+git pull
+kubectl apply -k deploy/k8s/overlays/prod
+
+# 查看 Pod 状态
+kubectl -n ruoyi get pods
+
+# 排查问题
+kubectl -n ruoyi logs deployment/ruoyi-gateway
+```
+
+部署完成后，即可通过 Ingress 域名访问前端与网关（示例：`https://ruoyi.prod.example.com`）。
+
+## 6. GitLab → Jenkins 自动触发
+
+1. 在 GitLab 项目中配置 Webhook，URL 指向 Jenkins Job 的 `Build with Parameters` 接口（或使用 GitLab 插件生成的触发 URL），勾选 `Push events`、`Merge request events`。
+2. Jenkins 端安装并配置 GitLab 插件，勾选 *Build when a change is pushed to GitLab*，并填写 GitLab 服务器地址与凭据。
+3. 可在 Jenkinsfile 中追加测试/扫描阶段或根据分支决定是否部署，例如：
+
+```groovy
+when {
+  expression { env.BRANCH_NAME == 'main' }
+}
+```
+
+## 7. 常见问题与优化建议
+
+- **镜像构建失败**：检查 Jenkins 节点是否具有 Docker 权限、Harbor 登录凭据是否正确。
+- **拉取镜像超时**：请在各节点配置 `/etc/docker/daemon.json` 镜像加速（阿里云 Registry Mirror）。
+- **Pod CrashLoopBackOff**：通过 `kubectl logs`、`kubectl describe` 排查，重点关注 Nacos、数据库连接是否正常。
+- **资源限制**：根据业务压力调整 Deployment 中 `resources` 配置，并结合 HPA 自动扩缩容。
+- **多环境隔离**：复制 `overlays/prod` 为 `overlays/dev`，修改镜像标签、ConfigMap、Ingress 域名，即可实现同一套基础清单的多集群复用。
+- **安全**：
+  - 使用 `SealedSecret` 或 `ExternalSecrets` 管理敏感信息；
+  - 开启 Jenkins 凭据审计，定期轮转密码；
+  - 在 Harbor 中启用镜像扫描和签名策略。
+
+## 8. 手动回滚与灰度发布
+
+- **镜像回滚**：使用 `kubectl rollout undo deployment/ruoyi-system -n ruoyi` 回滚到上一个 ReplicaSet。
+- **灰度**：可在 Jenkinsfile 中新增阶段，通过修改 Deployment 的 `image` 标签、Replica 数实现 A/B 测试；或引入 Argo Rollouts、Flagger 等工具。
+
+## 9. 后续扩展
+
+- 集成 SonarQube、SAST、单元测试覆盖率报告，提升质量门禁；
+- 接入 Prometheus + Grafana、EFK/ELK 构建监控与日志平台；
+- 使用 Helm/Argo CD/Flux 实现 GitOps 模式的持续交付。
+
+---
+
+如需进一步定制（多机房、弹性伸缩、自动化运维脚本等），可在上述基础上扩展。


### PR DESCRIPTION
## Summary
- add a Jenkins declarative pipeline to build, push and deploy ruoyi-cloud services
- provide Kubernetes base manifests and production overlay for ruoyi-cloud and its dependencies
- document the end-to-end CI/CD workflow for deploying on Alibaba Cloud ECS

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de2e7441a8832ab7c77425f8bbc280